### PR TITLE
Don't install --pre, --upgrade pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,8 @@ install Briefcase::
     $ cd traveltips
     $ python -m venv venv
     $ source venv/bin/activate
-    (venv) $ pip install --pre briefcase
+    (venv) $ pip install --upgrade pip
+    (venv) $ pip install briefcase
 
 You can then run the app in development mode::
 


### PR DESCRIPTION
briefcase was recently updated, so that the most recent package is not a prerelease
force a pip install to prevent any potential issues with package incompat