### PR TITLE
Add linux dependencies to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,13 @@ requires = [
     # '../../toga/src/gtk'
     'toga-gtk==0.3.0.dev20'
 ]
+system_requires = [
+    'libgirepository1.0-dev',
+    'libcairo2-dev',
+    'libpango1.0-dev',
+    'libwebkitgtk-3.0-0',
+    'gir1.2-webkit-3.0',
+]
 
 [tool.briefcase.app.traveltips.iOS]
 requires = [


### PR DESCRIPTION
I hope this will fix the problem described here https://github.com/freakboy3742/traveltips/pull/4#issuecomment-689351557

> Ah - I worked out what is going on with the Linux build: `pyproject.toml` doesn't have any of the Linux system dependencies defined. I would have generated `pyproject.toml` before the move to Docker-based packaging.